### PR TITLE
RN47.0 has removed `createJSModules` method

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNThumbnailPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNThumbnailPackage.java
@@ -16,7 +16,6 @@ public class RNThumbnailPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNThumbnailModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Hi,

RN47.0 has removed createJSModule method from ReactPackage.java. In order to make it work on Android with RN47.0, I have removed @overide annotation from RNMediaMetaPackage.java class.

Can you please merge and release so that we can seamlessly use this library on RN47.0 and above

Please let me know in case any changes are required

Thanks,
Pranav