### PR TITLE
Remove react-native peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
   },
   "author": "",
   "license": "",
-  "peerDependencies": {
-    "react-native": "^0.47.0"
-  },
   "dependencies": {
     "react-native-thumbnail": "^1.1.0"
   }


### PR DESCRIPTION
This is not a common practise with react-native libraries.
Most specify the compatible versions in their readme.