### PR TITLE
Remove dependency on react-native-thumbnail

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,5 @@
   "license": "",
   "peerDependencies": {
     "react-native": "^0.47.0"
-  },
-  "dependencies": {
-    "react-native-thumbnail": "^1.1.0"
   }
 }


### PR DESCRIPTION
Is there any reason why this package should have a dependency upon itself?