### PR TITLE
Update podspec

### DIFF
--- a/RNThumbnail.podspec
+++ b/RNThumbnail.podspec
@@ -1,7 +1,10 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name         = "RNThumbnail"
-  s.version      = "1.0.0"
+  s.version      = package['version']
   s.summary      = "RNThumbnail"
   s.description  = <<-DESC
                   RNThumbnail
@@ -13,7 +16,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/author/RNThumbnail"
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/RNThumbnail.git", :tag => "master" }
-  s.source_files  = "RNThumbnail/**/*.{h,m}"
+  s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
 
 


### PR DESCRIPTION
Similar libraries like `react-native-camera` all have their podspec file in the package root.

Also the source_files property was wrong.