### PR TITLE
Change compile to implementation in Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Get thumbnail from local media. Currently, it only supports for video.
   	```
 3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
   	```
-      compile project(':react-native-thumbnail')
+      implementation project(':react-native-thumbnail')
   	```
 
 ## Usage

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
   


### PR DESCRIPTION
This is required due to changes in Android Studio.

```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```